### PR TITLE
Allow body for DELETE requests

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -154,7 +154,7 @@ class Client
         $request = new Request($url);
         $data = isset($options['data']) ? $options['data'] : '';
         if ($data || $data === '0' || $data === 0) {
-            if (isset($options['method']) && (strtoupper($options['method']) === 'POST' || strtoupper($options['method']) === 'PUT' || strtoupper($options['method']) === 'PATCH')) {
+            if (isset($options['method']) && (strtoupper($options['method']) === 'POST' || strtoupper($options['method']) === 'PUT' || strtoupper($options['method']) === 'PATCH' || strtoupper($options['method']) === 'DELETE')) {
                 $request->write($options['data']);
             } else {
                 $options['query'] = $data;


### PR DESCRIPTION
Now DELETE requests can not contain body because all params passed to 'data' are converted to query params.