### PR TITLE
fix proxy bug

### DIFF
--- a/src/ConnectionPool.php
+++ b/src/ConnectionPool.php
@@ -218,24 +218,21 @@ class ConnectionPool extends Emitter
      */
     protected function create($address, bool $ssl = false, string $proxy = ''): AsyncTcpConnection
     {
-        $context = array(
-            'ssl' => array(
+        $context = [
+            'ssl' => [
                 'verify_peer' => false,
                 'verify_peer_name'  => false,
                 'allow_self_signed' => true
-            ),
-            'http' => array(
-                'proxy' => $proxy
-            ),
-        );
+            ]
+        ];
         if (!empty( $this->options['context'])) {
             $context = $this->options['context'];
         }
         if (!$ssl) {
             unset($context['ssl']);
         }
-        if (empty($proxy)) {
-            unset($context['http']['proxy']);
+        if ($proxy) {
+            $context['http']['proxy'] = $proxy;
         }
         if (!class_exists(Worker::class) || is_null(Worker::$globalEvent)) {
             throw new Exception('Only the workerman environment is supported.');

--- a/src/ConnectionPool.php
+++ b/src/ConnectionPool.php
@@ -223,16 +223,19 @@ class ConnectionPool extends Emitter
                 'verify_peer' => false,
                 'verify_peer_name'  => false,
                 'allow_self_signed' => true
+            ],
+            'http' => [
+                'proxy' => $proxy,
             ]
         ];
         if (!empty( $this->options['context'])) {
-            $context = $this->options['context'];
+            $context = array_merge($context, $this->options['context']);
         }
         if (!$ssl) {
             unset($context['ssl']);
         }
-        if ($proxy) {
-            $context['http']['proxy'] = $proxy;
+        if (empty($proxy)) {
+            unset($context['http']['proxy']);
         }
         if (!class_exists(Worker::class) || is_null(Worker::$globalEvent)) {
             throw new Exception('Only the workerman environment is supported.');


### PR DESCRIPTION
修复context被覆盖导致代理失效问题。
```php
require __DIR__ . '/vendor/autoload.php';
use Workerman\Worker;
$worker = new Worker();
$worker->onWorkerStart = function(){
    $options = [
        'max_conn_per_addr' => 128,
        'keepalive_timeout' => 15,
        'connect_timeout'   => 30,
        'timeout'           => 30,
            'context' => [
                'ssl' => [
                    'verify_peer' => false,
                    'verify_peer_name' => false,
                ]
            ]
    ];
    $http = new Workerman\Http\Client($options);

    $http->request('https://example.com/', [
        'method' => 'GET',
        'proxy' => 'http://127.0.0.1:1080',// 代理失效
        'success' => function ($response) {
            echo $response->getBody();
        },
        'error' => function ($exception) {
            echo $exception;
        }
    ]);
};
Worker::runAll();
```